### PR TITLE
Hyejeong/init data 29cm

### DIFF
--- a/src/main/java/com/flink/flink_backend/entity/CategoryMapping.java
+++ b/src/main/java/com/flink/flink_backend/entity/CategoryMapping.java
@@ -1,0 +1,26 @@
+package com.flink.flink_backend.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "category_mappings",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"platform","external_type","external_id"}))
+public class CategoryMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mapping_id")
+    private Long mappingId;
+
+    @Column(nullable = false, length = 50)
+    private String platform;          // "29cm"
+
+    @Column(name = "external_type", nullable = false, length = 20) // "middle" | "large"
+    private String externalType;
+
+    @Column(name = "external_id", nullable = false)
+    private Long externalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+}

--- a/src/main/java/com/flink/flink_backend/entity/ProductImage.java
+++ b/src/main/java/com/flink/flink_backend/entity/ProductImage.java
@@ -3,7 +3,9 @@ package com.flink.flink_backend.entity;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "product_images")
+//N+1 쿼리/과다 로딩 이슈로 인해서 모든 @ManyToOne을 LAZY 로딩으로 전환
+@Table(name = "product_images",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"product_id","image_url"}))
 public class ProductImage {
 
     @Id

--- a/src/main/java/com/flink/flink_backend/entity/ProductReview.java
+++ b/src/main/java/com/flink/flink_backend/entity/ProductReview.java
@@ -6,7 +6,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
-@Table(name = "product_reviews")
+@Table(name = "product_reviews",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"product_id","vendor_id","review_id"}))
 public class ProductReview {
 
     @Id

--- a/src/main/java/com/flink/flink_backend/entity/ReviewImage.java
+++ b/src/main/java/com/flink/flink_backend/entity/ReviewImage.java
@@ -3,7 +3,8 @@ package com.flink.flink_backend.entity;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "review_images")
+@Table(name = "review_images",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"product_review_id","image_url"}))
 public class ReviewImage {
 
     @Id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,18 @@
 ########################################
 # 1) ?????? ?? ??
 ########################################
-# ??? ??
+# ?????? ??
 spring.application.name=flink-backend
 
 # HTTP ?? (?? 8080)
 server.port=8080
 
 ########################################
-# 2) ????? (PostgreSQL ??)
+# 2) ?????? ?? (PostgreSQL ??)
 ########################################
 # JDBC URL (host, port, dbname)
 spring.datasource.url=jdbc:postgresql://localhost:5432/<YOUR_DB_NAME>
-# ?? ??
+# DB ????
 spring.datasource.username=<YOUR_DB_USERNAME>
 spring.datasource.password=<YOUR_DB_PASSWORD>
 # ??? ? (HikariCP ??)
@@ -26,24 +26,35 @@ spring.datasource.hikari.minimum-idle=2
 spring.jpa.hibernate.ddl-auto=update
 # SQL ?? ??
 spring.jpa.show-sql=true
-# ?? ???
+# SQL ???
 spring.jpa.properties.hibernate.format_sql=true
-# PostgreSQL Dialect ?? (?? ?)
+# PostgreSQL Dialect ??
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+# ??? ? SQL ?? ??
 spring.jpa.defer-datasource-initialization=true
-spring.sql.init.mode=never
+spring.sql.init.mode=always
+
 ########################################
-# 4) ?????? (Swagger / OpenAPI)
+# 4) API ?? ?? (Swagger / OpenAPI)
 ########################################
-# OpenAPI JSON ????? ??
+# OpenAPI JSON ?? ??
 springdoc.api-docs.path=/v3/api-docs
 # Swagger UI ?? (?? URL: /swagger-ui.html)
 springdoc.swagger-ui.path=/swagger-ui.html
 
 ########################################
-# 5) ?? (??)
+# 5) ?? ?? (SQL)
 ########################################
-# SQL ?? ?? ??
+# SQL ?? ??
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+########################################
+# 6) SQL ?? ?? ?? ??
+########################################
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=\
+  classpath:data_ref.sql,\
+  classpath:data_wconcept.sql,\
+  classpath:data_29cm.sql

--- a/src/main/resources/data_29cm.sql
+++ b/src/main/resources/data_29cm.sql
@@ -1,0 +1,40 @@
+-- 벤더
+INSERT INTO vendors (vendor_id, name, rating)
+VALUES (1,'29CM',4.5)
+    ON CONFLICT (vendor_id) DO UPDATE SET name=EXCLUDED.name, rating=EXCLUDED.rating;
+
+-- 상품 (itemNo를 product_id로 사용)
+INSERT INTO products (product_id, name, brand, description, thumbnail_url, created_at, updated_at)
+VALUES (987654321,'트렌치 코트','CITYBREEZE','테스트 상세','https://img.example/987654321.jpg',NOW(),NOW())
+    ON CONFLICT (product_id) DO UPDATE
+                                    SET name=EXCLUDED.name, brand=EXCLUDED.brand, description=EXCLUDED.description, thumbnail_url=EXCLUDED.thumbnail_url, updated_at=NOW();
+
+-- 이미지
+INSERT INTO product_images (product_id, image_url, order_index) VALUES
+                                                                    (987654321,'https://img.example/987654321_1.jpg',0),
+                                                                    (987654321,'https://img.example/987654321_2.jpg',1)
+    ON CONFLICT DO NOTHING;
+
+-- 가격
+INSERT INTO product_prices (product_id, vendor_id, price, shipping_fee, product_url, created_at)
+VALUES (987654321,1,25900,2500,'https://shop.29cm.co.kr/product/987654321',NOW());
+
+-- 리뷰
+INSERT INTO product_reviews (product_id, vendor_id, review_id, user_id, content, score, written_date, created_at)
+VALUES (987654321,1,1001,'abc123','예뻐요',4.5,'2025-06-01',NOW())
+    ON CONFLICT (product_id, vendor_id, review_id) DO UPDATE
+                                                          SET content=EXCLUDED.content, score=EXCLUDED.score, written_date=EXCLUDED.written_date;
+
+-- 리뷰 이미지
+INSERT INTO review_images (product_review_id, image_url, order_index)
+SELECT pr.product_review_id, 'https://img.example/rev1001_img1.jpg', 0
+FROM product_reviews pr
+WHERE pr.product_id=987654321 AND pr.vendor_id=1 AND pr.review_id=1001
+    ON CONFLICT DO NOTHING;
+
+-- 카테고리 연결
+INSERT INTO product_categories (category_id, product_id)
+SELECT cm.category_id, 987654321
+FROM category_mappings cm
+WHERE cm.platform='29cm' AND cm.external_type='middle' AND cm.external_id=268102100
+    ON CONFLICT DO NOTHING;

--- a/src/main/resources/data_ref.sql
+++ b/src/main/resources/data_ref.sql
@@ -1,0 +1,19 @@
+-- 카테고리 5종
+INSERT INTO categories (category_id, name, parent_id) VALUES
+                                                          (1,'아우터',NULL),
+                                                          (2,'상의',NULL),
+                                                          (3,'하의',NULL),
+                                                          (4,'드레스',NULL),
+                                                          (5,'기타',NULL)
+    ON CONFLICT (category_id) DO NOTHING;
+
+-- 29CM 외부ID → 내부 카테고리 매핑
+INSERT INTO category_mappings (platform, external_type, external_id, category_id) VALUES
+                                                                                      ('29cm','middle',268102100,1),
+                                                                                      ('29cm','middle',268103100,2),('29cm','middle',268105100,2),
+                                                                                      ('29cm','middle',268106100,3),('29cm','middle',268107100,3),
+                                                                                      ('29cm','middle',268104100,4),
+                                                                                      ('29cm','middle',268116100,5),
+                                                                                      ('29cm','large',271100100,5),('29cm','large',269100100,5),('29cm','large',305100100,5)
+    ON CONFLICT (platform, external_type, external_id)
+DO UPDATE SET category_id=EXCLUDED.category_id;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,132 @@
+-- ========================
+-- 1. 카테고리 (categories)
+-- ========================
+CREATE TABLE IF NOT EXISTS categories (
+                                          category_id BIGSERIAL PRIMARY KEY,
+                                          name        VARCHAR(255) NOT NULL,
+    icon_url    VARCHAR(2048),
+    parent_id   BIGINT
+    );
+
+-- ========================
+-- 2. 상품 (products)
+-- ========================
+CREATE TABLE IF NOT EXISTS products (
+                                        product_id    BIGINT PRIMARY KEY,
+                                        category_id   BIGINT,
+                                        name          VARCHAR(255) NOT NULL,
+    brand         VARCHAR(255),
+    description   TEXT,
+    thumbnail_url VARCHAR(2048),
+    created_at    TIMESTAMP DEFAULT NOW(),
+    updated_at    TIMESTAMP DEFAULT NOW()
+    );
+
+-- ========================
+-- 3. 상품 이미지 (product_images)
+-- ========================
+CREATE TABLE IF NOT EXISTS product_images (
+                                              image_id    BIGSERIAL PRIMARY KEY,
+                                              product_id  BIGINT NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    image_url   VARCHAR(2048),
+    order_index INT
+    );
+
+-- ========================
+-- 4. 벤더 (vendors)
+-- ========================
+CREATE TABLE IF NOT EXISTS vendors (
+                                       vendor_id BIGSERIAL PRIMARY KEY,
+                                       name      VARCHAR(100) NOT NULL,
+    rating    NUMERIC(2,1)
+    );
+
+-- ========================
+-- 5. 상품 가격 (product_prices)
+-- ========================
+CREATE TABLE IF NOT EXISTS product_prices (
+                                              price_id     BIGSERIAL PRIMARY KEY,
+                                              product_id   BIGINT NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    vendor_id    BIGINT NOT NULL REFERENCES vendors(vendor_id),
+    price        NUMERIC(12,2) NOT NULL,
+    shipping_fee NUMERIC(12,2),
+    total_price  NUMERIC(12,2) GENERATED ALWAYS AS (COALESCE(price,0) + COALESCE(shipping_fee,0)) STORED,
+    product_url  VARCHAR(2048),
+    created_at   TIMESTAMP DEFAULT NOW()
+    );
+
+-- ========================
+-- 6. 상품 리뷰 (product_reviews)
+-- ========================
+CREATE TABLE IF NOT EXISTS product_reviews (
+                                               product_review_id BIGSERIAL PRIMARY KEY,
+                                               product_id        BIGINT NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    vendor_id         BIGINT NOT NULL REFERENCES vendors(vendor_id),
+    review_id         BIGINT,
+    user_id           TEXT,
+    content           TEXT,
+    score             NUMERIC(2,1),
+    written_date      DATE,
+    created_at        TIMESTAMP DEFAULT NOW(),
+    UNIQUE (product_id, vendor_id, review_id)
+    );
+
+-- ========================
+-- 7. 리뷰 이미지 (review_images)
+-- ========================
+CREATE TABLE IF NOT EXISTS review_images (
+                                             image_id          BIGSERIAL PRIMARY KEY,
+                                             product_review_id BIGINT NOT NULL REFERENCES product_reviews(product_review_id) ON DELETE CASCADE,
+    image_url         VARCHAR(2048),
+    order_index       INT
+    );
+
+-- ========================
+-- 8. 상품-카테고리 연결 (product_categories)
+-- ========================
+CREATE TABLE IF NOT EXISTS product_categories (
+                                                  category_id BIGINT NOT NULL REFERENCES categories(category_id) ON DELETE CASCADE,
+    product_id  BIGINT NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    PRIMARY KEY (category_id, product_id)
+    );
+
+-- ========================
+-- 9. 외부 카테고리 매핑 (category_mappings)
+-- ========================
+CREATE TABLE IF NOT EXISTS category_mappings (
+                                                 mapping_id     BIGSERIAL PRIMARY KEY,
+                                                 platform       VARCHAR(50) NOT NULL,    -- 예: '29cm', 'wconcept'
+    external_type  VARCHAR(20) NOT NULL,    -- 'middle' | 'large' 등
+    external_id    BIGINT NOT NULL,
+    category_id    BIGINT NOT NULL REFERENCES categories(category_id) ON DELETE CASCADE,
+    UNIQUE(platform, external_type, external_id)
+    );
+
+-- ========================
+-- 인덱스 & 제약 조건
+-- ========================
+-- 이미지 중복 방지
+CREATE UNIQUE INDEX IF NOT EXISTS uq_product_image
+    ON product_images (product_id, image_url);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_review_image
+    ON review_images (product_review_id, image_url);
+
+-- 조회 성능 인덱스
+CREATE INDEX IF NOT EXISTS idx_product_images_product
+    ON product_images (product_id);
+
+CREATE INDEX IF NOT EXISTS idx_product_prices_prod
+    ON product_prices (product_id);
+
+CREATE INDEX IF NOT EXISTS idx_product_prices_vendor
+    ON product_prices (vendor_id);
+
+CREATE INDEX IF NOT EXISTS idx_reviews_product
+    ON product_reviews (product_id);
+
+CREATE INDEX IF NOT EXISTS idx_review_images_review
+    ON review_images (product_review_id);
+
+CREATE INDEX IF NOT EXISTS idx_pc_product
+    ON product_categories (product_id);


### PR DESCRIPTION
## 변경 유형

* [x] feat: 새로운 기능
* [ ] fix: 버그 수정
* [ ] docs: 문서 변경
* [x] refactor: 코드 리팩토링
* [x] chore: 기타 변경

## 설명

**요약**

* 29CM 초기 데이터 적재를 위한 스키마/시드 분리 및 환경 설정 적용
* JPA 연관 로딩 전략(LAZY) 정리로 N+1 예방

**세부 변경**

* `schema.sql`: 공통 테이블 생성(`products`, `product_images`, `vendors`, `product_prices`, `product_reviews`, `review_images`, `categories`, `product_categories`, `category_mappings`) + 인덱스/UNIQUE 제약
* `data_ref.sql`: 기준 데이터 추가(카테고리 5종, 29CM `middle/large` → 내부 카테고리 매핑)
* `data_wconcept.sql`: 기존 `data.sql`을 W컨셉 전용으로 리네임/분리
* `data_29cm.sql`: 29CM 샘플 데이터(벤더/상품/이미지/가격/리뷰) 및 카테고리 연결 시드
* `application.properties`: `spring.sql.init.schema|data-locations` 설정으로 다중 SQL 실행 순서 적용
* `CategoryMapping.java`: 플랫폼별 외부 카테고리 매핑 엔티티 추가(UNIQUE: platform, external\_type, external\_id)
* `ProductImage.java`, `ProductReview.java`, `ReviewImage.java`: `@ManyToOne(fetch = LAZY)`로 변경하여 불필요한 즉시 로딩(EAGER) 방지

**테스트 방법**

1. Spring Boot 기동 → 콘솔에서 SQL init 실행 확인
2. pgAdmin에서 간단 쿼리로 검증

   * `SELECT COUNT(*) FROM products;`
   * `SELECT pc.product_id, c.name FROM product_categories pc JOIN categories c USING(category_id) ORDER BY pc.product_id DESC LIMIT 10;`

## 연관 이슈

* Closes #<issue-number>

## 브랜치

* 작업 브랜치: `Hyejeong/init_data_29cm`
* 타겟 브랜치: `develop`

## 리뷰어

* @minseo

## 체크리스트

* [x] 커밋 메시지가 Conventional Commits 규칙을 따름
* [ ] 테스트 추가/수정 (필요 시)
* [x] `develop` 브랜치로 머지 대상 설정