### PR TITLE
chore: convert application.properties to UTF-8 & fix Korean comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,md}]
+indent_style = space
+indent_size = 2
+
+[*.{gradle,json,js,ts}]
+indent_style = space
+indent_size = 2
+
+[*.properties]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,9 @@ server.port=8080
 spring.datasource.url=jdbc:postgresql://localhost:5432/<YOUR_DB_NAME>
 # DB ????
 spring.datasource.username=<YOUR_DB_USERNAME>
+# DB ????
 spring.datasource.password=<YOUR_DB_PASSWORD>
+
 # ??? ? (HikariCP ??)
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=2
@@ -28,17 +30,17 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 # SQL ???
 spring.jpa.properties.hibernate.format_sql=true
-# PostgreSQL Dialect ??
+# PostgreSQL Dialect
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
-# ??? ? SQL ?? ??
+# ?? SQL ???? ?? ??
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 ########################################
 # 4) API ?? ?? (Swagger / OpenAPI)
 ########################################
-# OpenAPI JSON ?? ??
+# OpenAPI JSON ?????
 springdoc.api-docs.path=/v3/api-docs
 # Swagger UI ?? (?? URL: /swagger-ui.html)
 springdoc.swagger-ui.path=/swagger-ui.html
@@ -46,12 +48,13 @@ springdoc.swagger-ui.path=/swagger-ui.html
 ########################################
 # 5) ?? ?? (SQL)
 ########################################
-# SQL ?? ??
+# ???? SQL ??
 logging.level.org.hibernate.SQL=DEBUG
+# ??? ???? ??
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 ########################################
-# 6) SQL ?? ?? ?? ??
+# 6) SQL ??? ???? ??
 ########################################
 spring.sql.init.schema-locations=classpath:schema.sql
 spring.sql.init.data-locations=\


### PR DESCRIPTION
## 변경 유형

* [ ] feat: 새로운 기능
* [ ] fix: 버그 수정
* [ ] docs: 문서 변경
* [ ] refactor: 코드 리팩토링
* [x] chore: 기타 변경

## 설명

> `application.properties` 파일의 인코딩을 **CP949 → UTF-8** 으로 변환하고, 한글 주석이 `????`로 보이던 문제를 **정상 한글 주석**으로 수정했습니다.
> 애플리케이션 동작에 영향을 주는 **프로퍼티 값은 변경하지 않았습니다.**

### 상세

* 파일 인코딩: CP949 → **UTF-8 (no BOM)**
* 한글 주석 정리: 가독성 향상 및 오탈자/깨짐 제거
* 기타: 불필요한 공백/개행 최소 정리(기능 영향 없음)

### 배경

* GitHub는 텍스트 표시를 기본적으로 UTF-8로 가정합니다. 기존 CP949 저장으로 인해 한글 주석이 깨져 보였습니다.

### 영향도

* 런타임 동작 변화 없음 (주석/인코딩만 변경)
* CI/CD 및 설정 값은 동일

### 테스트/검증

* GitHub 웹 UI에서 `application.properties` 한글 주석이 정상 표기되는지 확인
* 로컬 부팅 테스트(예: `./gradlew bootRun`)로 설정 로딩 정상 여부 확인
* IntelliJ `File > File Properties > File Encoding`에서 UTF-8 적용 상태 확인

## 연관 이슈

* Closes #<issue-number> (없다면 제거 또는 N/A)

## 브랜치

* 작업 브랜치: `Hyejeong/init_data_29cm`
* 타겟 브랜치: `develop`

## 리뷰어

* @minseo

## 체크리스트

* [x] 커밋 메시지가 Conventional Commits 규칙을 따름 (`chore: convert application.properties to UTF-8 & fix Korean comments`)
* [ ] 테스트 추가/수정 (필요 시) — 해당 없음
* [x] `develop` 브랜치로 머지 대상 설정