### PR TITLE
feat: 상품 검색 및 목록 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Secret DB config
+src/main/resources/application-secret.properties

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,20 @@
 	<artifactId>flink-backend</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>flink-backend</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
+	<description>Flink Backend</description>
+	<url>https://github.com/Find-and-Share-with-Flink/flink-backend</url>
 	<licenses>
 		<license/>
 	</licenses>
 	<developers>
-		<developer/>
+		<developer>
+			<name>Hyejeong Park</name>
+			<email>park061138@gmail.com</email>
+		</developer>
+		<developer>
+			<name>Minseo Kang</name>
+			<email>kang20@sch.ac.kr</email>
+		</developer>
 	</developers>
 	<scm>
 		<connection/>
@@ -28,6 +35,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<lombok.version>1.18.30</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -51,6 +59,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -79,6 +88,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/flink/flink_backend/controller/ProductController.java
+++ b/src/main/java/com/flink/flink_backend/controller/ProductController.java
@@ -1,0 +1,27 @@
+package com.flink.flink_backend.controller;
+
+import com.flink.flink_backend.dto.PageResponse;
+import com.flink.flink_backend.dto.ProductListItemDto;
+import com.flink.flink_backend.service.ProductQueryService;
+import org.springframework.web.bind.annotation.*;
+
+/** 상품 검색/상세 REST 컨트롤러 */
+@RestController
+@RequestMapping("/api/v1")
+public class ProductController {
+
+    private final ProductQueryService service;
+    public ProductController(ProductQueryService service) { this.service = service; }
+
+    /** GET /api/v1/products/search
+     *  - query: 이름/브랜드 키워드(옵션)
+     *  - page/size: 페이지네이션
+     */
+    @GetMapping("/products/search")
+    public PageResponse<ProductListItemDto> search(
+        @RequestParam(required = false) String query,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size) {
+        return service.search(query, page, size);
+    }
+}

--- a/src/main/java/com/flink/flink_backend/dto/PageResponse.java
+++ b/src/main/java/com/flink/flink_backend/dto/PageResponse.java
@@ -1,0 +1,19 @@
+package com.flink.flink_backend.dto;
+
+import java.util.List;
+
+/** 페이지네이션 공통 응답 래퍼 */
+public class PageResponse<T> {
+    private final List<T> data;  // 현재 페이지 데이터
+    private final int page;      // 현재 페이지 번호(1-base)
+    private final int size;      // 페이지 크기
+    private final long total;    // 전체 건수
+
+    public PageResponse(List<T> data, int page, int size, long total) {
+        this.data = data; this.page = page; this.size = size; this.total = total;
+    }
+    public List<T> getData() { return data; }
+    public int getPage() { return page; }
+    public int getSize() { return size; }
+    public long getTotal() { return total; }
+}

--- a/src/main/java/com/flink/flink_backend/dto/ProductListItemDto.java
+++ b/src/main/java/com/flink/flink_backend/dto/ProductListItemDto.java
@@ -1,0 +1,26 @@
+package com.flink.flink_backend.dto;
+
+/** 상품 목록의 한 아이템 DTO */
+public class ProductListItemDto {
+    private final Long product_id;      // 상품 ID
+    private final String name;          // 상품명
+    private final String brand;         // 브랜드명
+    private final String thumbnail_url; // 썸네일 URL
+    private final Double min_price;     // 최저가(가격 테이블 MIN)
+    private final Integer review_count; // 리뷰 수
+    private final Double avg_rating;    // 평균 평점
+
+    public ProductListItemDto(Long product_id, String name, String brand, String thumbnail_url,
+                              Double min_price, Integer review_count, Double avg_rating) {
+        this.product_id = product_id; this.name = name; this.brand = brand;
+        this.thumbnail_url = thumbnail_url; this.min_price = min_price;
+        this.review_count = review_count; this.avg_rating = avg_rating;
+    }
+    public Long getProduct_id() { return product_id; }
+    public String getName() { return name; }
+    public String getBrand() { return brand; }
+    public String getThumbnail_url() { return thumbnail_url; }
+    public Double getMin_price() { return min_price; }
+    public Integer getReview_count() { return review_count; }
+    public Double getAvg_rating() { return avg_rating; }
+}

--- a/src/main/java/com/flink/flink_backend/entity/ProductReview.java
+++ b/src/main/java/com/flink/flink_backend/entity/ProductReview.java
@@ -1,6 +1,7 @@
 package com.flink.flink_backend.entity;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,7 +33,14 @@ public class ProductReview {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    /*
+    ProductReview.score 타입과 DB 스키마의 컬럼 타입이 달라서 오류 발생했음
+    엔티티의 Float를 DB의 NUMERIC(2,1)에 맞춰 BigDecimal로 변경 진행
+    (수정 전)
     private Float score;
+    */
+    @Column(precision = 2, scale = 1)
+    private BigDecimal score;
 
     @Column(name = "written_date")
     private LocalDate writtenDate;

--- a/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
+++ b/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
@@ -1,0 +1,62 @@
+package com.flink.flink_backend.service;
+
+import com.flink.flink_backend.dto.PageResponse;
+import com.flink.flink_backend.dto.ProductListItemDto;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/** 상품 조회용 쿼리 서비스 */
+@Service
+public class ProductQueryService {
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public ProductQueryService(NamedParameterJdbcTemplate jdbc) { this.jdbc = jdbc; }
+
+    /** 상품 목록 검색 (이름/브랜드 LIKE, 최저가/리뷰집계 JOIN) */
+    public PageResponse<ProductListItemDto> search(String query, int page, int size) {
+        int offset = Math.max(0, (page - 1) * size);
+        var params = new MapSqlParameterSource()
+            .addValue("query", (query == null || query.isBlank()) ? null : "%" + query + "%")
+            .addValue("limit", size).addValue("offset", offset);
+
+        // 전체 개수 조회
+        long total = jdbc.queryForObject("""
+      SELECT COUNT(*) FROM products p
+      WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+    """, params, Long.class);
+
+        // 페이지 데이터 + 가격/리뷰 집계
+        var rows = jdbc.query("""
+      WITH base AS (
+        SELECT p.product_id, p.name, p.brand, p.thumbnail_url
+        FROM products p
+        WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+        ORDER BY p.product_id DESC
+        OFFSET :offset LIMIT :limit
+      ),
+      price AS ( SELECT product_id, MIN(total_price) AS min_price FROM product_prices GROUP BY product_id ),
+      review AS ( SELECT product_id, COUNT(*) AS review_count, ROUND(AVG(score)::numeric,1) AS avg_rating
+                  FROM product_reviews GROUP BY product_id )
+      SELECT b.product_id, b.name, b.brand, b.thumbnail_url,
+             COALESCE(pr.min_price,0) AS min_price,
+             COALESCE(rv.review_count,0) AS review_count,
+             COALESCE(rv.avg_rating,0) AS avg_rating
+      FROM base b
+      LEFT JOIN price pr ON pr.product_id = b.product_id
+      LEFT JOIN review rv ON rv.product_id = b.product_id
+    """, params, (rs, i) -> new ProductListItemDto(
+            rs.getLong("product_id"),
+            rs.getString("name"),
+            rs.getString("brand"),
+            rs.getString("thumbnail_url"),
+            rs.getDouble("min_price"),
+            rs.getInt("review_count"),
+            rs.getDouble("avg_rating")
+        ));
+
+        return new PageResponse<>(rows, page, size, total);
+    }
+}

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,0 +1,2 @@
+spring.datasource.username=flink
+spring.datasource.password=flink1234

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,49 +1,58 @@
 ########################################
-# 1) ?????? ?? ??
+# 1) Application basic settings
 ########################################
-# ??? ??
 spring.application.name=flink-backend
+spring.jackson.property-naming-strategy=SNAKE_CASE
 
-# HTTP ?? (?? 8080)
+# HTTP server port (default: 8080)
 server.port=8080
 
 ########################################
-# 2) ????? (PostgreSQL ??)
+# 2) Database (PostgreSQL connection)
 ########################################
 # JDBC URL (host, port, dbname)
-spring.datasource.url=jdbc:postgresql://localhost:5432/<YOUR_DB_NAME>
-# ?? ??
-spring.datasource.username=<YOUR_DB_USERNAME>
-spring.datasource.password=<YOUR_DB_PASSWORD>
-# ??? ? (HikariCP ??)
+spring.datasource.url=jdbc:postgresql://localhost:5433/flink
+
+# Import username and password from secret file
+spring.config.import=optional:application-secret.properties
+
+# HikariCP connection pool settings
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=2
 
 ########################################
-# 3) JPA / Hibernate ??
+# 3) JPA / Hibernate settings
 ########################################
 # DDL auto: create | create-drop | update | validate | none
-spring.jpa.hibernate.ddl-auto=update
-# SQL ?? ??
+spring.jpa.hibernate.ddl-auto=validate
+
+# Show executed SQL
 spring.jpa.show-sql=true
-# ?? ???
+
+# Format SQL output
 spring.jpa.properties.hibernate.format_sql=true
-# PostgreSQL Dialect ?? (?? ?)
+
+# PostgreSQL dialect
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+# Initialize settings
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=never
+
 ########################################
-# 4) ?????? (Swagger / OpenAPI)
+# 4) API documentation (Swagger / OpenAPI)
 ########################################
-# OpenAPI JSON ????? ??
+# OpenAPI JSON endpoint
 springdoc.api-docs.path=/v3/api-docs
-# Swagger UI ?? (?? URL: /swagger-ui.html)
+
+# Swagger UI endpoint (URL: /swagger-ui.html)
 springdoc.swagger-ui.path=/swagger-ui.html
 
 ########################################
-# 5) ?? (??)
+# 5) Logging (for debugging)
 ########################################
-# SQL ?? ?? ??
+# Show SQL queries
 logging.level.org.hibernate.SQL=DEBUG
+
+# Show SQL parameter bindings
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/data_29cm.sql
+++ b/src/main/resources/data_29cm.sql
@@ -11,7 +11,7 @@ INSERT INTO product_images (product_id, image_url, order_index) VALUES
     ON CONFLICT DO NOTHING;
 
 -- 가격
-INSERT INTO product_prices (product_id, vendor_id, price, total_price, shipping_fee, product_url, created_at)
+INSERT INTO product_prices (product_id, vendor_id, price, shipping_fee, product_url, created_at)
 VALUES (987654321,2,25900,28400,2500,'https://shop.29cm.co.kr/product/987654321',NOW());
 
 -- 리뷰


### PR DESCRIPTION
## 변경 유형
- [x] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] docs: 문서 변경
- [ ] refactor: 코드 리팩토링
- [x] chore: 기타 변경

## 설명
> 상품 검색 및 목록 조회 기능을 위한 REST API를 구현하였습니다.
> 
> **주요 기능:**
> - GET `/api/v1/products/search` 엔드포인트 추가
> - 상품명/브랜드 키워드 검색 기능 (LIKE 검색)
> - 페이지네이션 지원 (page, size 파라미터)
> - 최저가, 리뷰 수, 평균 평점 집계 포함
> 
> **구현된 컴포넌트:**
> - `ProductController`: REST API 엔드포인트
> - `ProductQueryService`: 상품 검색 및 목록 조회 서비스
> - `ProductListItemDto`: 상품 목록 아이템 DTO
> - `PageResponse<T>`: 페이지네이션 공통 응답 래퍼
> 
> **수정 사항:**
> - PostgreSQL 파라미터 타입 오류 해결 (`:query::text IS NULL` → `:query IS NULL`)
> - ProductReview.score 타입을 Float → BigDecimal로 변경 (DB NUMERIC(2,1)과 매칭)
> - pom.xml 메타데이터 보완 (라이선스, 개발자 정보, SCM 정보)
> - Lombok 버전 명시 및 Maven Compiler Plugin 설정 개선
> 
> **데이터베이스 관련:**
> - DB 자동 계산 컬럼 total_price 제거
> - JSON snake_case 설정 추가
> - DB 계정 정보 분리 (application-secret.properties)

## 연관 이슈
- 

## 브랜치
- 작업 브랜치: `feature/products-search`
- 타겟 브랜치: `develop`

## 리뷰어
- @hye-jeong-park , @mseo39 

## 체크리스트
- [x] 커밋 메시지가 Conventional Commits 규칙을 따름
- [x] 테스트 추가/수정 (필요 시)
- [x] `develop` 브랜치로 머지 대상 설정

## 커밋 히스토리
- `feat(controller)`: 상품 검색 REST API 엔드포인트 구현
- `feat(service)`: 상품 검색 및 목록 조회 서비스 구현
- `feat(dto)`: 상품 목록 아이템 DTO 클래스 추가
- `feat(dto)`: 페이지네이션 공통 응답 래퍼 클래스 추가
- `fix`: "score"의 타입인 Float를 DB의 NUMERIC(2,1)에 맞춰 BigDecimal로 변경
- `fix(data_29cm.sql)`: DB 자동 계산 컬럼 total_price 제거
- `chore`: JSON snake_case 설정 추가, db 계정 정보 분리
- `chore`: lombok 버전 추가 및 기본 정보 추가