### PR TITLE
feat: 상품 상세 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Secret DB config
+src/main/resources/application-secret.properties

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,20 @@
 	<artifactId>flink-backend</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>flink-backend</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
+	<description>Flink Backend</description>
+	<url>https://github.com/Find-and-Share-with-Flink/flink-backend</url>
 	<licenses>
 		<license/>
 	</licenses>
 	<developers>
-		<developer/>
+		<developer>
+			<name>Hyejeong Park</name>
+			<email>park061138@gmail.com</email>
+		</developer>
+		<developer>
+			<name>Minseo Kang</name>
+			<email>kang20@sch.ac.kr</email>
+		</developer>
 	</developers>
 	<scm>
 		<connection/>
@@ -28,6 +35,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<lombok.version>1.18.30</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -51,6 +59,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -79,6 +88,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/flink/flink_backend/controller/ProductController.java
+++ b/src/main/java/com/flink/flink_backend/controller/ProductController.java
@@ -1,9 +1,12 @@
 package com.flink.flink_backend.controller;
 
+import com.flink.flink_backend.dto.ProductDetailDto;
 import com.flink.flink_backend.dto.PageResponse;
 import com.flink.flink_backend.dto.ProductListItemDto;
 import com.flink.flink_backend.service.ProductQueryService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 /** 상품 검색/상세 REST 컨트롤러 */
 @RestController
@@ -23,5 +26,16 @@ public class ProductController {
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(defaultValue = "20") int size) {
         return service.search(query, page, size);
+    }
+
+    /** GET /api/v1/products/{product_id} - 상품 상세 */
+    @GetMapping("/products/{product_id}")
+    public ProductDetailDto detail(@PathVariable("product_id") Long productId) {
+        var dto = service.detail(productId);
+        if (dto == null) {
+            // 존재하지 않는 경우 404 반환
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found");
+        }
+        return dto;
     }
 }

--- a/src/main/java/com/flink/flink_backend/controller/ProductController.java
+++ b/src/main/java/com/flink/flink_backend/controller/ProductController.java
@@ -1,0 +1,27 @@
+package com.flink.flink_backend.controller;
+
+import com.flink.flink_backend.dto.PageResponse;
+import com.flink.flink_backend.dto.ProductListItemDto;
+import com.flink.flink_backend.service.ProductQueryService;
+import org.springframework.web.bind.annotation.*;
+
+/** 상품 검색/상세 REST 컨트롤러 */
+@RestController
+@RequestMapping("/api/v1")
+public class ProductController {
+
+    private final ProductQueryService service;
+    public ProductController(ProductQueryService service) { this.service = service; }
+
+    /** GET /api/v1/products/search
+     *  - query: 이름/브랜드 키워드(옵션)
+     *  - page/size: 페이지네이션
+     */
+    @GetMapping("/products/search")
+    public PageResponse<ProductListItemDto> search(
+        @RequestParam(required = false) String query,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size) {
+        return service.search(query, page, size);
+    }
+}

--- a/src/main/java/com/flink/flink_backend/dto/PageResponse.java
+++ b/src/main/java/com/flink/flink_backend/dto/PageResponse.java
@@ -1,0 +1,19 @@
+package com.flink.flink_backend.dto;
+
+import java.util.List;
+
+/** 페이지네이션 공통 응답 래퍼 */
+public class PageResponse<T> {
+    private final List<T> data;  // 현재 페이지 데이터
+    private final int page;      // 현재 페이지 번호(1-base)
+    private final int size;      // 페이지 크기
+    private final long total;    // 전체 건수
+
+    public PageResponse(List<T> data, int page, int size, long total) {
+        this.data = data; this.page = page; this.size = size; this.total = total;
+    }
+    public List<T> getData() { return data; }
+    public int getPage() { return page; }
+    public int getSize() { return size; }
+    public long getTotal() { return total; }
+}

--- a/src/main/java/com/flink/flink_backend/dto/ProductDetailDto.java
+++ b/src/main/java/com/flink/flink_backend/dto/ProductDetailDto.java
@@ -1,0 +1,41 @@
+package com.flink.flink_backend.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 상품 상세 DTO (이미지/최저가/리뷰집계 포함) */
+public class ProductDetailDto {
+    private Long product_id;           // 상품 ID
+    private String name;               // 상품명
+    private String brand;              // 브랜드명
+    private List<ImageDto> images;     // 이미지 리스트(정렬 포함)
+    private Double min_price;          // 최저가
+    private Integer review_count;      // 리뷰 수
+    private Double avg_rating;         // 평균 평점
+    private LocalDateTime created_at;  // 생성 시각
+
+    /** 상세 이미지 DTO (순서값 포함) */
+    public static class ImageDto {
+        public String image_url;
+        public Integer order_index;
+        public ImageDto(String url, Integer idx) { this.image_url = url; this.order_index = idx; }
+    }
+
+    // getter/setter
+    public Long getProduct_id(){ return product_id; }
+    public void setProduct_id(Long v){ this.product_id = v; }
+    public String getName(){ return name; }
+    public void setName(String v){ this.name = v; }
+    public String getBrand(){ return brand; }
+    public void setBrand(String v){ this.brand = v; }
+    public List<ImageDto> getImages(){ return images; }
+    public void setImages(List<ImageDto> v){ this.images = v; }
+    public Double getMin_price(){ return min_price; }
+    public void setMin_price(Double v){ this.min_price = v; }
+    public Integer getReview_count(){ return review_count; }
+    public void setReview_count(Integer v){ this.review_count = v; }
+    public Double getAvg_rating(){ return avg_rating; }
+    public void setAvg_rating(Double v){ this.avg_rating = v; }
+    public LocalDateTime getCreated_at(){ return created_at; }
+    public void setCreated_at(LocalDateTime v){ this.created_at = v; }
+}

--- a/src/main/java/com/flink/flink_backend/dto/ProductListItemDto.java
+++ b/src/main/java/com/flink/flink_backend/dto/ProductListItemDto.java
@@ -1,0 +1,26 @@
+package com.flink.flink_backend.dto;
+
+/** 상품 목록의 한 아이템 DTO */
+public class ProductListItemDto {
+    private final Long product_id;      // 상품 ID
+    private final String name;          // 상품명
+    private final String brand;         // 브랜드명
+    private final String thumbnail_url; // 썸네일 URL
+    private final Double min_price;     // 최저가(가격 테이블 MIN)
+    private final Integer review_count; // 리뷰 수
+    private final Double avg_rating;    // 평균 평점
+
+    public ProductListItemDto(Long product_id, String name, String brand, String thumbnail_url,
+                              Double min_price, Integer review_count, Double avg_rating) {
+        this.product_id = product_id; this.name = name; this.brand = brand;
+        this.thumbnail_url = thumbnail_url; this.min_price = min_price;
+        this.review_count = review_count; this.avg_rating = avg_rating;
+    }
+    public Long getProduct_id() { return product_id; }
+    public String getName() { return name; }
+    public String getBrand() { return brand; }
+    public String getThumbnail_url() { return thumbnail_url; }
+    public Double getMin_price() { return min_price; }
+    public Integer getReview_count() { return review_count; }
+    public Double getAvg_rating() { return avg_rating; }
+}

--- a/src/main/java/com/flink/flink_backend/entity/ProductReview.java
+++ b/src/main/java/com/flink/flink_backend/entity/ProductReview.java
@@ -1,6 +1,7 @@
 package com.flink.flink_backend.entity;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,7 +33,14 @@ public class ProductReview {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    /*
+    ProductReview.score 타입과 DB 스키마의 컬럼 타입이 달라서 오류 발생했음
+    엔티티의 Float를 DB의 NUMERIC(2,1)에 맞춰 BigDecimal로 변경 진행
+    (수정 전)
     private Float score;
+    */
+    @Column(precision = 2, scale = 1)
+    private BigDecimal score;
 
     @Column(name = "written_date")
     private LocalDate writtenDate;

--- a/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
+++ b/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
@@ -2,6 +2,7 @@ package com.flink.flink_backend.service;
 
 import com.flink.flink_backend.dto.PageResponse;
 import com.flink.flink_backend.dto.ProductListItemDto;
+import com.flink.flink_backend.dto.ProductDetailDto;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -58,5 +59,51 @@ public class ProductQueryService {
         ));
 
         return new PageResponse<>(rows, page, size, total);
+    }
+
+    /** 상품 상세 조회 (헤더 + 이미지 목록) */
+    public ProductDetailDto detail(Long productId) {
+        var p = new MapSqlParameterSource().addValue("pid", productId);
+
+        // 1) 헤더(상품 기본 + 최저가/리뷰 집계)
+        var dto = jdbc.query("""
+      WITH price AS ( SELECT MIN(total_price) AS min_price FROM product_prices WHERE product_id=:pid ),
+           review AS ( SELECT COUNT(*) AS review_count, ROUND(AVG(score)::numeric,1) AS avg_rating
+                       FROM product_reviews WHERE product_id=:pid )
+      SELECT p.product_id, p.name, p.brand, p.created_at,
+             COALESCE(pr.min_price,0) AS min_price,
+             COALESCE(rv.review_count,0) AS review_count,
+             COALESCE(rv.avg_rating,0) AS avg_rating
+      FROM products p
+      LEFT JOIN price  pr ON TRUE
+      LEFT JOIN review rv ON TRUE
+      WHERE p.product_id = :pid
+    """, p, rs -> {
+            if (!rs.next()) return null;
+            var d = new ProductDetailDto();
+            d.setProduct_id(rs.getLong("product_id"));
+            d.setName(rs.getString("name"));
+            d.setBrand(rs.getString("brand"));
+            d.setCreated_at(rs.getTimestamp("created_at").toLocalDateTime());
+            d.setMin_price(rs.getDouble("min_price"));
+            d.setReview_count(rs.getInt("review_count"));
+            d.setAvg_rating(rs.getDouble("avg_rating"));
+            return d;
+        });
+        if (dto == null) return null;
+
+        // 2) 이미지 목록 (order_index ASC, null은 뒤로)
+        var images = jdbc.query("""
+      SELECT image_url, order_index
+      FROM product_images
+      WHERE product_id = :pid
+      ORDER BY order_index ASC NULLS LAST, image_id ASC
+    """, p, (rs, i) -> new ProductDetailDto.ImageDto(
+            rs.getString("image_url"),
+            (Integer) rs.getObject("order_index") // order_index가 null일 수 있어 getObject 사용
+        ));
+
+        dto.setImages(images);
+        return dto;
     }
 }

--- a/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
+++ b/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
@@ -26,7 +26,7 @@ public class ProductQueryService {
         // 전체 개수 조회
         long total = jdbc.queryForObject("""
       SELECT COUNT(*) FROM products p
-      WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+      WHERE (:query::text IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
     """, params, Long.class);
 
         // 페이지 데이터 + 가격/리뷰 집계
@@ -34,7 +34,7 @@ public class ProductQueryService {
       WITH base AS (
         SELECT p.product_id, p.name, p.brand, p.thumbnail_url
         FROM products p
-        WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+        WHERE (:query::text IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
         ORDER BY p.product_id DESC
         OFFSET :offset LIMIT :limit
       ),

--- a/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
+++ b/src/main/java/com/flink/flink_backend/service/ProductQueryService.java
@@ -1,0 +1,62 @@
+package com.flink.flink_backend.service;
+
+import com.flink.flink_backend.dto.PageResponse;
+import com.flink.flink_backend.dto.ProductListItemDto;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/** 상품 조회용 쿼리 서비스 */
+@Service
+public class ProductQueryService {
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public ProductQueryService(NamedParameterJdbcTemplate jdbc) { this.jdbc = jdbc; }
+
+    /** 상품 목록 검색 (이름/브랜드 LIKE, 최저가/리뷰집계 JOIN) */
+    public PageResponse<ProductListItemDto> search(String query, int page, int size) {
+        int offset = Math.max(0, (page - 1) * size);
+        var params = new MapSqlParameterSource()
+            .addValue("query", (query == null || query.isBlank()) ? null : "%" + query + "%")
+            .addValue("limit", size).addValue("offset", offset);
+
+        // 전체 개수 조회
+        long total = jdbc.queryForObject("""
+      SELECT COUNT(*) FROM products p
+      WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+    """, params, Long.class);
+
+        // 페이지 데이터 + 가격/리뷰 집계
+        var rows = jdbc.query("""
+      WITH base AS (
+        SELECT p.product_id, p.name, p.brand, p.thumbnail_url
+        FROM products p
+        WHERE (:query IS NULL OR p.name ILIKE :query OR p.brand ILIKE :query)
+        ORDER BY p.product_id DESC
+        OFFSET :offset LIMIT :limit
+      ),
+      price AS ( SELECT product_id, MIN(total_price) AS min_price FROM product_prices GROUP BY product_id ),
+      review AS ( SELECT product_id, COUNT(*) AS review_count, ROUND(AVG(score)::numeric,1) AS avg_rating
+                  FROM product_reviews GROUP BY product_id )
+      SELECT b.product_id, b.name, b.brand, b.thumbnail_url,
+             COALESCE(pr.min_price,0) AS min_price,
+             COALESCE(rv.review_count,0) AS review_count,
+             COALESCE(rv.avg_rating,0) AS avg_rating
+      FROM base b
+      LEFT JOIN price pr ON pr.product_id = b.product_id
+      LEFT JOIN review rv ON rv.product_id = b.product_id
+    """, params, (rs, i) -> new ProductListItemDto(
+            rs.getLong("product_id"),
+            rs.getString("name"),
+            rs.getString("brand"),
+            rs.getString("thumbnail_url"),
+            rs.getDouble("min_price"),
+            rs.getInt("review_count"),
+            rs.getDouble("avg_rating")
+        ));
+
+        return new PageResponse<>(rows, page, size, total);
+    }
+}

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,0 +1,2 @@
+spring.datasource.username=flink
+spring.datasource.password=flink1234

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,49 +1,58 @@
 ########################################
-# 1) ?????? ?? ??
+# 1) Application basic settings
 ########################################
-# ??? ??
 spring.application.name=flink-backend
+spring.jackson.property-naming-strategy=SNAKE_CASE
 
-# HTTP ?? (?? 8080)
+# HTTP server port (default: 8080)
 server.port=8080
 
 ########################################
-# 2) ????? (PostgreSQL ??)
+# 2) Database (PostgreSQL connection)
 ########################################
 # JDBC URL (host, port, dbname)
-spring.datasource.url=jdbc:postgresql://localhost:5432/<YOUR_DB_NAME>
-# ?? ??
-spring.datasource.username=<YOUR_DB_USERNAME>
-spring.datasource.password=<YOUR_DB_PASSWORD>
-# ??? ? (HikariCP ??)
+spring.datasource.url=jdbc:postgresql://localhost:5433/flink
+
+# Import username and password from secret file
+spring.config.import=optional:application-secret.properties
+
+# HikariCP connection pool settings
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=2
 
 ########################################
-# 3) JPA / Hibernate ??
+# 3) JPA / Hibernate settings
 ########################################
 # DDL auto: create | create-drop | update | validate | none
-spring.jpa.hibernate.ddl-auto=update
-# SQL ?? ??
+spring.jpa.hibernate.ddl-auto=validate
+
+# Show executed SQL
 spring.jpa.show-sql=true
-# ?? ???
+
+# Format SQL output
 spring.jpa.properties.hibernate.format_sql=true
-# PostgreSQL Dialect ?? (?? ?)
+
+# PostgreSQL dialect
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
+# Initialize settings
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=never
+
 ########################################
-# 4) ?????? (Swagger / OpenAPI)
+# 4) API documentation (Swagger / OpenAPI)
 ########################################
-# OpenAPI JSON ????? ??
+# OpenAPI JSON endpoint
 springdoc.api-docs.path=/v3/api-docs
-# Swagger UI ?? (?? URL: /swagger-ui.html)
+
+# Swagger UI endpoint (URL: /swagger-ui.html)
 springdoc.swagger-ui.path=/swagger-ui.html
 
 ########################################
-# 5) ?? (??)
+# 5) Logging (for debugging)
 ########################################
-# SQL ?? ?? ??
+# Show SQL queries
 logging.level.org.hibernate.SQL=DEBUG
+
+# Show SQL parameter bindings
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/data_29cm.sql
+++ b/src/main/resources/data_29cm.sql
@@ -11,7 +11,7 @@ INSERT INTO product_images (product_id, image_url, order_index) VALUES
     ON CONFLICT DO NOTHING;
 
 -- 가격
-INSERT INTO product_prices (product_id, vendor_id, price, total_price, shipping_fee, product_url, created_at)
+INSERT INTO product_prices (product_id, vendor_id, price, shipping_fee, product_url, created_at)
 VALUES (987654321,2,25900,28400,2500,'https://shop.29cm.co.kr/product/987654321',NOW());
 
 -- 리뷰

--- a/src/test/java/com/flink/flink_backend/ProductControllerTest.java
+++ b/src/test/java/com/flink/flink_backend/ProductControllerTest.java
@@ -1,0 +1,66 @@
+package com.flink.flink_backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureWebMvc
+@ActiveProfiles("test")
+public class ProductControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @Test
+    public void testSearchProducts() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        // 1. 기본 검색 (파라미터 없음)
+        mockMvc.perform(get("/api/v1/products/search"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.total").exists());
+
+        // 2. 검색어 포함 검색
+        mockMvc.perform(get("/api/v1/products/search")
+                        .param("query", "테스트")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.size").value(10));
+
+        // 3. 페이지네이션 테스트
+        mockMvc.perform(get("/api/v1/products/search")
+                        .param("page", "2")
+                        .param("size", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(2))
+                .andExpect(jsonPath("$.size").value(5));
+    }
+
+    @Test
+    public void testSearchProductsWithEmptyQuery() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        // 빈 검색어 테스트
+        mockMvc.perform(get("/api/v1/products/search")
+                        .param("query", ""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists());
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,17 @@
+# 테스트용 프로파일 설정
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA 설정
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# SQL 초기화 비활성화 (테스트에서는 별도로 데이터 삽입)
+spring.sql.init.mode=never
+
+# 로깅 레벨
+logging.level.org.springframework.web=DEBUG
+logging.level.com.flink.flink_backend=DEBUG


### PR DESCRIPTION
## 변경 유형
- [x] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] docs: 문서 변경
- [ ] refactor: 코드 리팩토링
- [ ] chore: 기타 변경

## 설명
> 상품 상세 정보 조회 기능을 위한 REST API를 구현하였습니다.
> 
> **주요 기능:**
> - GET `/api/v1/products/{product_id}` 엔드포인트 추가
> - 상품 기본 정보 + 이미지 목록 조회
> - 최저가, 리뷰 수, 평균 평점 집계 포함
> - 이미지 순서 정렬 (order_index 기준, null은 뒤로)
> 
> **구현된 컴포넌트:**
> - `ProductController`: 상품 상세 조회 엔드포인트 추가
> - `ProductQueryService.detail()`: 상품 상세 조회 서비스 로직
> - `ProductDetailDto`: 상품 상세 정보 DTO
> - `ProductDetailDto.ImageDto`: 상품 이미지 정보 DTO (순서값 포함)
> 
> **수정 사항:**
> - PostgreSQL 파라미터 타입 오류 해결 (`:query::text IS NULL` → `:query IS NULL`)
> - SQL 쿼리 최적화 (WITH 절 사용, LEFT JOIN으로 집계 데이터 조회)
> - 이미지 정렬 로직 구현 (order_index ASC NULLS LAST)
> 
> **테스트 관련:**
> - ProductController 통합 테스트 추가
> - 테스트용 application-test.properties 추가

## 연관 이슈
- 

## 브랜치
- 작업 브랜치: `feature/product-detail`
- 타겟 브랜치: `develop`

## 리뷰어
- @hye-jeong-park , @mseo39 

## 체크리스트
- [x] 커밋 메시지가 Conventional Commits 규칙을 따름
- [x] 테스트 추가/수정 (필요 시)
- [x] `develop` 브랜치로 머지 대상 설정

## 커밋 히스토리
- `feat(api)`: GET /api/v1/products/{product_id} 엔드포인트 추가
- `feat(service)`: 상품 상세 조회 로직 추가(detail)
- `feat(dto)`: 상품 상세 DTO 추가
- `fix`: PostgreSQL IS NULL 조건에서 파라미터 타입 오류 해결
- `test`: 테스트용 application-test.properties 추가
- `test`: ProductController 통합 테스트 추가